### PR TITLE
Support for other servers that mutate line formatting, min & max mem flags.

### DIFF
--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -39,7 +39,12 @@ var defaultServerProps = {
   'generate-structures': 'true',
   'view-distance': '10',
   'spawn-protection': '16',
-  'motd': 'A Minecraft Server'
+  'motd': 'A Minecraft Server',
+  'flags': {
+    'min-mem': '512',
+    'max-mem': '512'
+  },
+  'done-string': '\ INFO]: Done '
 };
 
 module.exports = Wrap;
@@ -123,7 +128,13 @@ Wrap.prototype.startServer=function(propOverrides, done) {
       return done(new Error("The file " + self.MC_SERVER_JAR + " doesn't exist."));
     }
 
-    self.mcServer = spawn('java', ['-jar', self.MC_SERVER_JAR, 'nogui'], {
+    self.mcServer = spawn('java', [
+      '-jar',
+      '-Xms' + defaultServerProps.flags['min-mem'] + 'M',
+      '-Xmx' + defaultServerProps.flags['max-mem'] + 'M',
+      self.MC_SERVER_JAR,
+      'nogui'
+    ], {
       stdio: 'pipe',
       cwd: self.MC_SERVER_PATH
     });
@@ -146,10 +157,13 @@ Wrap.prototype.startServer=function(propOverrides, done) {
 
     self.mcServer.on('line', onLine);
     self.mcServer.on('line', function(line) {
+      process.stderr.write('.');
       self.emit('line',line);
     });
     function onLine(line) {
-      if(/\ INFO]: Done /.test(line)) {
+      var regex = new RegExp(defaultServerProps['done-string']);
+
+      if(regex.test(line)) {
         self.mcServer.removeListener('line', onLine);
         done();
       }

--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -44,7 +44,7 @@ var defaultServerProps = {
     'min-mem': '512',
     'max-mem': '512'
   },
-  'done-string': '\ INFO]: Done '
+  'done-string': '\[Server thread\/INFO\]: Done'
 };
 
 module.exports = Wrap;

--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -146,11 +146,10 @@ Wrap.prototype.startServer=function(propOverrides, done) {
 
     self.mcServer.on('line', onLine);
     self.mcServer.on('line', function(line) {
-      process.stderr.write('.');
       self.emit('line',line);
     });
     function onLine(line) {
-      if(/\[Server thread\/INFO\]: Done/.test(line)) {
+      if(/\ INFO]: Done /.test(line)) {
         self.mcServer.removeListener('line', onLine);
         done();
       }


### PR DESCRIPTION
Figured I'd send this over, it might be useful to others. I've modified the `defaultServerProps` to add min and max mem startup flags. In addition I've also added the ability to put custom regex in for the done command. Without this using something like Spigot will not work because it will never kick off `done()` due to the mutation of what onLine gets. 