### PR TITLE
feat(wrap.js): Support for other jars, min max flags

### DIFF
--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -44,11 +44,16 @@ var defaultServerProps = {
 
 module.exports = Wrap;
 
-function Wrap(MC_SERVER_JAR,MC_SERVER_PATH)
+function Wrap(MC_SERVER_JAR,MC_SERVER_PATH,OPTIONS)
 {
   EventEmitter.call(this);
   this.MC_SERVER_JAR=MC_SERVER_JAR;
   this.MC_SERVER_PATH=MC_SERVER_PATH;
+  this.OPTIONS = {
+    minMem: OPTIONS.minMem || '512',
+    maxMem: OPTIONS.maxMem || '512',
+    doneRegex: OPTIONS.doneRegex || new RegExp(/\[Server thread\/INFO\]: Done/)
+  };
 }
 util.inherits(Wrap, EventEmitter);
 
@@ -123,7 +128,13 @@ Wrap.prototype.startServer=function(propOverrides, done) {
       return done(new Error("The file " + self.MC_SERVER_JAR + " doesn't exist."));
     }
 
-    self.mcServer = spawn('java', ['-jar', self.MC_SERVER_JAR, 'nogui'], {
+    self.mcServer = spawn('java', [
+      '-jar',
+      '-Xms' + self.OPTIONS.minMem + 'M',
+      '-Xmx' + self.OPTIONS.maxMem + 'M',
+      self.MC_SERVER_JAR,
+      'nogui'
+    ], {
       stdio: 'pipe',
       cwd: self.MC_SERVER_PATH
     });
@@ -150,7 +161,9 @@ Wrap.prototype.startServer=function(propOverrides, done) {
       self.emit('line',line);
     });
     function onLine(line) {
-      if(/\[Server thread\/INFO\]: Done/.test(line)) {
+      var regex = self.OPTIONS.doneRegex;
+
+      if(regex.test(line)) {
         self.mcServer.removeListener('line', onLine);
         done();
       }

--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -50,9 +50,9 @@ function Wrap(MC_SERVER_JAR,MC_SERVER_PATH,OPTIONS)
   this.MC_SERVER_JAR=MC_SERVER_JAR;
   this.MC_SERVER_PATH=MC_SERVER_PATH;
   this.OPTIONS = {
-    minMem: OPTIONS.minMem || '512',
-    maxMem: OPTIONS.maxMem || '512',
-    doneRegex: OPTIONS.doneRegex || new RegExp(/\[Server thread\/INFO\]: Done/)
+    minMem: (OPTIONS && OPTIONS.minMem) ? OPTIONS.minMem : '512',
+    maxMem: (OPTIONS && OPTIONS.maxMem) ? OPTIONS.maxMem : '512',
+    doneRegex: (OPTIONS && OPTIONS.doneRegex) ? OPTIONS.doneRegex : new RegExp(/\[Server thread\/INFO\]: Done/)
   };
 }
 util.inherits(Wrap, EventEmitter);


### PR DESCRIPTION
Figured I'd send this over, it might be useful to others. I've modified the defaultServerProps to add min and max mem startup flags. In addition I've also added the ability to put custom regex in for the done command. Without this using something like Spigot will not work because it will never kick off done() due to the mutation of what onLine gets.

As noted in the previous PR I've moved the now options into their own object, I did however leave the default regex the same after comparing it with what exists currently in master. Couldn't figure out the unit tests though, I tried running them locally both with my changes, and with the original Wrap.js before I made changes. Getting errors like: 

```
1) server_session start and stop the server:
     Error: The file undefined doesn't exist.
```

