### PR TITLE
download: retry transient network failures

### DIFF
--- a/lib/launcher_download.js
+++ b/lib/launcher_download.js
@@ -33,11 +33,15 @@ class LauncherDownload {
 
   getVersionsList () {
     if (this.versionsList) { return Promise.resolve(this.versionsList) }
-    return fetch('https://launchermeta.mojang.com/mc/game/version_manifest.json')
-      .then(res => res.json()).then((json) => {
-        this.versionsList = json
-        return json
+    return withRetry('version_manifest.json', () =>
+      fetch('https://launchermeta.mojang.com/mc/game/version_manifest.json').then(res => {
+        if (!res.ok) throw new Error(`unexpected status ${res.status} fetching version manifest`)
+        return res.json()
       })
+    ).then((json) => {
+      this.versionsList = json
+      return json
+    })
   }
 
   getVersionInfos (version) {
@@ -154,6 +158,21 @@ class LauncherDownload {
 
 const pathsPromises = {}
 
+// Mojang's CDN occasionally drops a connection mid-response ("Premature close"), failing an
+// otherwise-healthy request. Retry transient failures a few times with linear backoff so a
+// single blip doesn't fail the whole download (and the CI job that depends on it).
+async function withRetry (label, fn, retries = 3) {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await fn()
+    } catch (err) {
+      if (attempt > retries) throw err
+      debug(`${label} failed (attempt ${attempt}/${retries}): ${err.message}; retrying in ${attempt}s`)
+      await new Promise(resolve => setTimeout(resolve, 1000 * attempt))
+    }
+  }
+}
+
 function downloadFile (url, path, size, sha1) {
   assert.notStrictEqual(url, undefined)
   if (pathsPromises[path]) { return pathsPromises[path] }
@@ -165,14 +184,16 @@ function downloadFile (url, path, size, sha1) {
       const dirPath = parts.join('/')
       return mkdirp(dirPath)
         .then(() => {
-          return queue.add(() => new Promise((resolve, reject) => {
+          return queue.add(() => withRetry(`download ${url}`, () => new Promise((resolve, reject) => {
             fetch(url).then(res => {
+              if (!res.ok) { reject(new Error(`unexpected status ${res.status} fetching ${url}`)); return }
               const fileStream = fs.createWriteStream(path)
               res.body.pipe(fileStream)
-              res.body.on('error', err => reject(err))
+              res.body.on('error', reject)
+              fileStream.on('error', reject)
               fileStream.on('finish', () => resolve())
-            })
-          }))
+            }).catch(reject)
+          })))
         })
         .then(() => checkFile(path, size, sha1))
     })


### PR DESCRIPTION
getVersionsList fetches Mojang's version_manifest.json with a single, un-retried fetch; Mojang's CDN intermittently drops the connection mid-response ("Premature close"), failing the fetch and every download (and CI job) that starts there. Wrap the manifest fetch and file downloads in a small retry-with-backoff so a transient blip self-heals, and add the missing .catch so a rejected download fetch rejects instead of hanging.